### PR TITLE
Add a timeout to Jenkins build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
         skipDefaultCheckout()
         buildDiscarder(logRotator(numToKeepStr: "10"))
         timestamps()
+        timeout time: 2, unit: 'HOURS'
     }
 
     stages {


### PR DESCRIPTION
This will prevent zombie jobs from running amok.  It actually filled the Amber CI machine with 1.4 TB of logs last week... this change will fix that.